### PR TITLE
Fix bad validation for Swish payments

### DIFF
--- a/includes/class-wc-gateway-payex-swish.php
+++ b/includes/class-wc-gateway-payex-swish.php
@@ -197,9 +197,9 @@ class WC_Gateway_Payex_Psp_Swish extends WC_Gateway_Payex_Cc
 		}
 
 		$matches = array();
-		preg_match( '/^(\+47)(?:4[015-8]|5[89]|87|9\d)\d{6}$/u', $billing_phone, $matches );
+		preg_match( '/^\+46[0-9]{6,13}$/u', $billing_phone, $matches );
 		if ( ! isset( $matches[0] ) || $matches[0] !== $billing_phone ) {
-			wc_add_notice( __( 'Input your number like this +47xxxxxxxxx', 'woocommerce-gateway-payex-psp' ), 'error' );
+			wc_add_notice( __( 'Input your number like this +46xxxxxxxxx', 'woocommerce-gateway-payex-psp' ), 'error' );
 			return FALSE;
 		}
 


### PR DESCRIPTION
Update regex to use the same rules required by the actual payment portal. Earlier it were validating Norwegian numbers which does not really make sense for Swish